### PR TITLE
misc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Whenever you make an http request, add one or more of the hystrix-clj options to
                                    :hystrix/breaker-request-volume  20
                                    :hystrix/breaker-error-percent   50
                                    :hystrix/breaker-sleep-window-ms 5000
-                                   :hystrix/bad-request-pred client-error?}}
+                                   :hystrix/bad-request-pred        client-error?}}
 ```
 Any values not supplied will be set to their default values as above. Requests with no Hystrix-related keys won't use Hystrix.
 

--- a/src/clj_http_hystrix/core.clj
+++ b/src/clj_http_hystrix/core.clj
@@ -66,10 +66,10 @@
                                    (.withCoreSize threads)
                                    (.withMaxQueueSize (:hystrix/queue-size config 5))
                                    (.withQueueSizeRejectionThreshold (:hystrix/queue-size config 5)))]
-    (-> (HystrixCommand$Setter/withGroupKey (group-key group))
-        (.andCommandKey (command-key (:hystrix/command-key config :default)))
-        (.andCommandPropertiesDefaults command-configurator)
-        (.andThreadPoolPropertiesDefaults thread-pool-configurator))))
+    (doto (HystrixCommand$Setter/withGroupKey (group-key group))
+      (.andCommandKey (command-key (:hystrix/command-key config :default)))
+      (.andCommandPropertiesDefaults command-configurator)
+      (.andThreadPoolPropertiesDefaults thread-pool-configurator))))
 
 (defn ^:private log-error [command-name ^HystrixCommand context]
   (let [message (format "Failed to complete %s %s" command-name (.getExecutionEvents context))]
@@ -104,7 +104,7 @@
                                                                                   :message "Bad request pred"
                                                                                   :stack-trace (stack-trace)})))
                                            resp))
-          wrap-exception-reponse (fn [resp] ((http/wrap-exceptions (constantly resp)) (assoc req :throw-exceptions true)))
+          wrap-exception-response (fn [resp] ((http/wrap-exceptions (constantly resp)) (assoc req :throw-exceptions true)))
           ^HystrixCommand$Setter configurator (configurator req)
           logging-context (or (MDC/getCopyOfContextMap) {})
           command (proxy [HystrixCommand] [configurator]
@@ -120,7 +120,7 @@
                           (assoc :throw-exceptions false)
                           f
                           wrap-bad-request
-                          wrap-exception-reponse)))]
+                          wrap-exception-response)))]
       (handle-exception #(.execute command) req))
     (f req)))
 

--- a/src/clj_http_hystrix/core.clj
+++ b/src/clj_http_hystrix/core.clj
@@ -121,8 +121,9 @@
       (handle-exception #(.execute command) req))
     (f req)))
 
-(defn add-hook []
+(defn add-hook
   "Activate clj-http-hystrix to wrap all clj-http client requests as
   hystrix commands."
-  (when (not (some-> (meta http/request) :robert.hooke/hooks deref (contains? #'wrap-hystrix)))
+  []
+  (when-not (some-> (meta http/request) :robert.hooke/hooks deref (contains? #'wrap-hystrix))
     (hooke/add-hook #'http/request #'wrap-hystrix)))

--- a/src/clj_http_hystrix/core.clj
+++ b/src/clj_http_hystrix/core.clj
@@ -20,6 +20,9 @@
     :hystrix/threads
     :hystrix/queue-size
     :hystrix/timeout-ms
+    :hystrix/breaker-request-volume
+    :hystrix/breaker-error-percent
+    :hystrix/breaker-sleep-window-ms
     :hystrix/bad-request-pred})
 
 (defn default-fallback [req resp]


### PR DESCRIPTION
lets users inspect `add-hook` with `(doc add-hook)`
