### PR TITLE
Custom defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Whenever you make an http request, add one or more of the hystrix-clj options to
                                    :hystrix/breaker-request-volume  20
                                    :hystrix/breaker-error-percent   50
                                    :hystrix/breaker-sleep-window-ms 5000
-                                   :hystrix/bad-request-pred        client-error?}}
+                                   :hystrix/bad-request-pred        client-error?})
 ```
 Any values not supplied will be set to their default values as above. Requests with no Hystrix-related keys won't use Hystrix.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,21 @@ Whenever you make an http request, add one or more of the hystrix-clj options to
                                    :hystrix/breaker-sleep-window-ms 5000
                                    :hystrix/bad-request-pred        client-error?})
 ```
-Any values not supplied will be set to their default values as above. Requests with no Hystrix-related keys won't use Hystrix.
+
+Requests without any `:hystrix/...` keys won't use Hystrix. Any values not supplied will be set to their default values as above. Custom default values can also be specified when registering with `add-hook`:
+
+```clj
+(clj-http-hystrix.core/add-hook {:hystrix/timeout-ms 2500
+                                 :hystrix/queue-size 12})
+
+;; now each request will fallback to these if not supplied
+(http/get "http://www.google.com" {:hystrix/command-key :google})
+;;=> {:hystrix/command-key :google
+;;    :hystrix/timeout-ms 2500
+;;    :hystrix/queue-size 12
+;;    ... (rest are clj-http-hystrix defaults)
+;;    }
+```
 
 ## Bad requests
 

--- a/src/clj_http_hystrix/core.clj
+++ b/src/clj_http_hystrix/core.clj
@@ -134,5 +134,4 @@
   "Activate clj-http-hystrix to wrap all clj-http client requests as
   hystrix commands."
   []
-  (when-not (some-> (meta http/request) :robert.hooke/hooks deref (contains? #'wrap-hystrix))
-    (hooke/add-hook #'http/request #'wrap-hystrix)))
+  (hooke/add-hook #'http/request #'wrap-hystrix))

--- a/src/clj_http_hystrix/core.clj
+++ b/src/clj_http_hystrix/core.clj
@@ -111,14 +111,15 @@
         (let [req (merge defaults req)
               bad-request-pred (:hystrix/bad-request-pred req)
               fallback (:hystrix/fallback-fn req)
-              wrap-bad-request (fn [resp] (if (bad-request-pred req resp)
-                                            (throw
-                                              (HystrixBadRequestException.
-                                                "Ignored bad request"
-                                                (wrap {:object resp
-                                                       :message "Bad request pred"
-                                                       :stack-trace (stack-trace)})))
-                                            resp))
+              wrap-bad-request (fn [resp]
+                                 (if (bad-request-pred req resp)
+                                   (throw
+                                     (HystrixBadRequestException.
+                                       "Ignored bad request"
+                                       (wrap {:object resp
+                                              :message "Bad request pred"
+                                              :stack-trace (stack-trace)})))
+                                   resp))
               wrap-exception-response (fn [resp]
                                         ((http/wrap-exceptions (constantly resp))
                                          (assoc req :throw-exceptions true)))

--- a/test/clj_http_hystrix/core_test.clj
+++ b/test/clj_http_hystrix/core_test.clj
@@ -178,8 +178,35 @@
 
 (fact "add-hook can be safely called more than once"
       (count (get-hooks)) => 1
-      (get (get-hooks) #'wrap-hystrix) => #'wrap-hystrix
+      (contains? (get-hooks) :clj-http-hystrix.core/wrap-hystrix) => true
       ;call add-hook a few more times and ensure only one hook is present
-      (add-hook), (add-hook), (add-hook)
+      (add-hook), (add-hook)
       (count (get-hooks)) => 1
-      (get (get-hooks) #'wrap-hystrix) => #'wrap-hystrix)
+      (contains? (get-hooks) :clj-http-hystrix.core/wrap-hystrix) => true)
+
+(fact "remove-hook removes clj-http-hystrix hook"
+      (count (get-hooks)) => 1
+      (contains? (get-hooks) :clj-http-hystrix.core/wrap-hystrix) => true
+      (remove-hook)
+      (get-hooks) => nil
+      ;can be called more than once
+      (remove-hook), (remove-hook)
+      (get-hooks) => nil
+      ;restore hook for additional testing
+      (add-hook))
+
+(fact "add-hook with user-defaults will override base configuration, but not call configuration"
+      (rest-driven
+        [{:method :GET
+          :url "/"}
+         {:status 500
+          :times 3}]
+        (make-hystrix-call {})
+        => (throws clojure.lang.ExceptionInfo "clj-http: status 500")
+        ;set custom default for fallback-fn
+        (remove-hook)
+        (add-hook {:hystrix/fallback-fn (constantly "bar")})
+        (make-hystrix-call {}) => "bar"
+        (make-hystrix-call {:hystrix/fallback-fn (constantly "baz")}) => "baz")
+      (remove-hook)
+      (add-hook))


### PR DESCRIPTION
Implementation of feature suggested in #8.
- base configuration values are now centralized in a single map
- renamed `wrap-hystrix` to `hystrix-wrapper`, because it now closes over the defaults first, before creating and returning a function that is equivalent to `wrap-hystrix`. not sure if this is necessary but was hoping it would make the function more clear. this made the diff really big, but the significant change inside the returned function is just `req (merge defaults req)`. there are also some whitespace changes as lines were getting really long from nesting.
- using 3-arity version of `robert.hooke/add-hooke`, and specifying a key explicitly, since the wrapping function is now lexically scoped and does not have a root var.
- discovered that we can safely `robert.hooke/add-hook` multiple times without concern and as long as the key or var is the same, so I removed the add-hook check.
