### PR TITLE
support using clj-http-hystrix as middleware

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[clj-http "2.0.1"]
+  :dependencies [[clj-http "2.3.0"]
                  [com.netflix.hystrix/hystrix-clj "1.4.23"]
                  [org.clojure/clojure "1.8.0"]
                  [org.clojure/tools.logging "0.3.1"]

--- a/src/clj_http_hystrix/core.clj
+++ b/src/clj_http_hystrix/core.clj
@@ -161,3 +161,22 @@
   "Deactivate clj-http-hystrix."
   []
   (hooke/remove-hook #'http/request ::wrap-hystrix))
+
+(defn wrap-hystrix
+  "Middleware for adding hystrix to a clj-http client request.
+
+  Alternative to `add-hook`. Do not use both `wrap-hystrix` and `add-hook`.
+
+    ;; add wrap-hystrix to the middleware chain
+    (clj-http.client/with-additional-middleware [wrap-hystrix]
+      (clj-http.client/get ...))
+
+    ;; or if you want to provide your own defaults
+    (clj-http.client/with-additional-middleware [(partial wrap-hystrix {:hystrix/timeout-ms 6000})]
+      (clj-http.client/get ...))
+  "
+  ([client] (wrap-hystrix {} client))
+  ([defaults client]
+   (let [wrapper (hystrix-wrapper defaults)]
+     (fn [req]
+       (wrapper client req)))))


### PR DESCRIPTION
add clj-http client middleware that wraps the HTTP call with hystrix.